### PR TITLE
build fixes for OSX 10.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.so
+*.dylib
 plugins/*-swh.lv2/manifest.ttl
 plugins/*-swh.lv2/manifest.ttl.in
 plugins/*-swh.lv2/plugin.c

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ DARWIN := $(shell uname | grep Darwin)
 OS := $(shell uname -s)
 
 ifdef DARWIN
-EXT = so
-CC = gcc
-PLUGIN_CFLAGS = -Wall -I. -Iinclude -I/usr/local/include -O3 -fomit-frame-pointer -fstrength-reduce -funroll-loops -fPIC -DPIC -DFFTW3 -arch i386 -ffast-math -msse -fno-common -flat_namespace -bundle -isysroot /Developer/SDKs/MacOSX10.4u.sdk $(CFLAGS)
-PLUGIN_LDFLAGS = -arch i386 -dynamic -Wl,-syslibroot,/Developer/SDKs/MacOSX10.5u.sdk -bundle -multiply_defined suppress -lc $(LDFLAGS)
+EXT = dylib
+CC = clang
+PLUGIN_CFLAGS = -Wall -Wno-unused-variable -Wno-self-assign -I. -Iinclude -O3 -fomit-frame-pointer -funroll-loops -DFFTW3 -arch x86_64 -ffast-math -msse -fno-common $(CFLAGS)
+PLUGIN_LDFLAGS = -arch x86_64 -dynamiclib $(LDFLAGS)
 BUILD_PLUGINS = $(PLUGINS) $(FFT_PLUGINS)
 RT =
 else
@@ -74,8 +74,8 @@ util: util/blo.o util/iir.o util/db.o util/rms.o util/pitchscale.o
 %.o: %.c
 	$(CC) $(PLUGIN_CFLAGS) $($(NAME)_CFLAGS) $*.c -c -o $@
 
-%.so: NAME = $(shell echo $@ | sed 's/plugins\/\(.*\)-swh.*/\1/')
-%.so: %.xml %.o %.ttl
+%.$(EXT): NAME = $(shell echo $@ | sed 's/plugins\/\(.*\)-swh.*/\1/')
+%.$(EXT): %.xml %.o %.ttl
 	$(CC) $*.o $(PLUGIN_LDFLAGS) $($(NAME)_LDFLAGS) -o $@
 	cp $@ $*-$(OS).$(EXT)
 	sed 's/@OS@/$(OS)/g' < `dirname $@`/manifest.ttl.in > `dirname $@`/manifest.ttl

--- a/plugins/gong-swh.lv2/plugin.xml
+++ b/plugins/gong-swh.lv2/plugin.xml
@@ -10,6 +10,9 @@
     <code>
       #include "util/waveguide_nl.h"
 
+      /* required for clang compilation */
+      void waveguide_nl_process(waveguide_nl *wg, float in0, float in1, float *out0, float *out1);
+
       #define RUN_WG(n, junct_a, junct_b) waveguide_nl_process(w[n], junct_a - out[n*2+1], junct_b - out[n*2], out+n*2, out+n*2+1)
     </code>
   </global>

--- a/plugins/plate-swh.lv2/plugin.xml
+++ b/plugins/plate-swh.lv2/plugin.xml
@@ -13,6 +13,9 @@
       #define LP_INNER 0.96f
       #define LP_OUTER 0.983f
 
+      /* required for clang compilation */
+      void waveguide_nl_process_lin(waveguide_nl *wg, float in0, float in1, float *out0, float *out1);
+
       #define RUN_WG(n, junct_a, junct_b) waveguide_nl_process_lin(w[n], junct_a - out[n*2+1], junct_b - out[n*2], out+n*2, out+n*2+1)
     </code>
   </global>

--- a/plugins/sifter-swh.lv2/plugin.xml
+++ b/plugins/sifter-swh.lv2/plugin.xml
@@ -13,6 +13,9 @@
 
 inline int partition(LADSPA_Data array[], int left, int right);
 
+/* required for clang compilation */
+void q_sort(LADSPA_Data array[], int left, int right);
+
 inline void q_sort(LADSPA_Data array[], int left, int right) {
 	float pivot = partition(array, left, right);
 


### PR DESCRIPTION
Hi Steve,

Not sure if you're accepting pull requests on this one these days, but
if you are, here are a few changes required to get it to build (with
clang) on OSX 10.8. I think it should work back to at least 10.6, but
I haven't tested that. It has also been tested on Ubuntu 12.10 and
still seems to work fine there.

the main additions/changes are:
- shared libraries on osx is use .dylib extension
- add clang flags to build 64-bit dylibs
- added a couple of function prototypes to help clang with inlined
  functions
- add *.dylib pattern to .gitignore
