### PR TITLE
Use standard LV2 user installation directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ install:
 install-system: INSTALL_DIR_REALLY=$(INSTALL_DIR)
 install-system: all install-really
 
-install-user: INSTALL_DIR_REALLY=~/.lv2/bundles
+install-user: INSTALL_DIR_REALLY=~/.lv2
 install-user: all install-really
 
 install-really:


### PR DESCRIPTION
Apparently nobody used this, since hosts would just skip ~/.lv2/bundles as an invalid bundle due to lack of manifest.ttl

Correct behaviour is to install bundles in ~/.lv2 which may only contain bundles.