### PR TITLE
offset plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ single_para-swh.lv2 sinus_wavewrapper-swh.lv2 smooth_decimate-swh.lv2 \
 split-swh.lv2 surround_encoder-swh.lv2 svf-swh.lv2 \
 tape_delay-swh.lv2 transient-swh.lv2 triple_para-swh.lv2 valve-swh.lv2 \
 valve_rect-swh.lv2 vynil-swh.lv2 wave_terrain-swh.lv2 xfade-swh.lv2 \
-zm1-swh.lv2 \
+zm1-swh.lv2 offset-swh.lv2 \
 a_law-swh.lv2 u_law-swh.lv2
 
 FFT_PLUGINS = mbeq-swh.lv2 pitch_scale-swh.lv2

--- a/plugins/offset-swh.lv2/plugin.xml
+++ b/plugins/offset-swh.lv2/plugin.xml
@@ -36,15 +36,16 @@
 
     <callback event="run"><![CDATA[
 
-      long buffer_r_pos, i;
+      long buffer_r_pos, delay_delta, i;
 
       // subtract the plugin's latency (results in no audible offset)
       // and apply user-configured delay (results in the desired offset):
       buffer_r_pos = BUFFER_POS(buffer_w_pos - (MAX_OFFSET + (long)delay));
 
-      //for (i=0; i<delay_delta; i++) {
-      //  buffer[BUFFER_POS(buffer_w_pos + i)] = 0;
-      //}
+      delay_delta = (long)delay - last_delay;
+      for (; delay_delta<0; delay_delta++) {
+        buffer[BUFFER_POS(buffer_r_pos + delay_delta)] = 0.0f;
+      }
 
       for (i=0; i<sample_count; i++) {
         buffer[buffer_w_pos] = input[i];

--- a/plugins/offset-swh.lv2/plugin.xml
+++ b/plugins/offset-swh.lv2/plugin.xml
@@ -12,11 +12,13 @@
       #define MAX_OFFSET 24000
       #define BUFFER_LEN (MAX_OFFSET*2 + 1)
       #define BUFFER_POS(a) (((a) + BUFFER_LEN) % BUFFER_LEN)
+      #define MAX(a, b) ((a) > (b) ? (a) : (b))
+      #define MIN(a, b) ((a) < (b) ? (a) : (b))
     ]]></code>
   </global>
 
   <plugin label="offset" id="1916" class="UtilityPlugin">
-    <name>Offset, sample-based (i.e. positive or negative delay)</name>
+    <name>Offset, sample-based</name>
     <p>Intended to be used to eliminate offset between tracks (e.g. single sound source recorded from different distances).</p>
 
     <callback event="instantiate"><![CDATA[
@@ -26,8 +28,7 @@
     <callback event="activate"><![CDATA[
       memset(buffer, 0, BUFFER_LEN * sizeof(LADSPA_Data));
       plugin_data->buffer_w_pos = 0;
-      plugin_data->last_delay = 0; //(float)*plugin_data->delay;
-      *(plugin_data->latency) = MAX_OFFSET;
+      plugin_data->last_offset = 0;
     ]]></callback>
 
     <callback event="cleanup"><![CDATA[
@@ -36,15 +37,34 @@
 
     <callback event="run"><![CDATA[
 
-      long buffer_r_pos, delay_delta, i;
+      long buffer_r_pos, offset_delta, i;
 
-      // subtract the plugin's latency (results in no audible offset)
-      // and apply user-configured delay (results in the desired offset):
-      buffer_r_pos = BUFFER_POS(buffer_w_pos - (MAX_OFFSET + (long)delay));
+      if (automatable > 0) {
 
-      delay_delta = (long)delay - last_delay;
-      for (; delay_delta<0; delay_delta++) {
-        buffer[BUFFER_POS(buffer_r_pos + delay_delta)] = 0.0f;
+        // report the maximum offset to the host
+        *(plugin_data->latency) = MAX_OFFSET;
+
+        // and subtract the maximum offset by default
+        // (results in no audible offset)
+        buffer_r_pos = BUFFER_POS(buffer_w_pos - MAX_OFFSET);
+
+        // apply user-configured offset (results in the desired offset):
+        buffer_r_pos = BUFFER_POS(buffer_r_pos + (long)offset);
+
+      } else {
+        // report the currently required latency
+        // (the LV2 specification does not allow a negative latency)
+        *(plugin_data->latency) = MAX((long)offset, 0);
+
+        // if delaying, apply the configured offset
+        // (otherwise we rely on the host's latency compensation)
+        buffer_r_pos = BUFFER_POS(buffer_w_pos + MIN((long)offset, 0));
+      }
+
+      // if the offset increases, zero the buffer accordingly
+      offset_delta = (long)offset - last_offset;
+      for (; offset_delta>0; offset_delta--) {
+        buffer[BUFFER_POS(buffer_r_pos - offset_delta)] = 0.0f;
       }
 
       for (i=0; i<sample_count; i++) {
@@ -57,12 +77,19 @@
       }
 
       plugin_data->buffer_w_pos = buffer_w_pos;
-      plugin_data->last_delay = (long)delay;
+      plugin_data->last_offset = (long)offset;
+
     ]]></callback>
 
-    <port label="delay" dir="input" type="control" hint="default_0,causes_artifacts">
-      <name>delay (in samples)</name>
+    <port label="offset" dir="input" type="control" hint="default_0,causes_artifacts">
+      <name>offset (in samples)</name>
+      <p>If positive, input will be played earlier; if negative, it's a delay.</p>
       <range min="-24000" max="24000" steps="48001"/>
+    </port>
+
+    <port label="automatable" dir="input" type="control" hint="default_0,toggled">
+      <name>automatable (possibly adds playback delay)</name>
+      <p>Turn this off if the offset does not change when rolling as the required buffer possibly adds a playback delay otherwise.</p>
     </port>
 
     <port label="input" dir="input" type="audio">
@@ -81,7 +108,7 @@
     <instance-data label="buffer" type="LADSPA_Data *" />
 
     <instance-data label="buffer_w_pos" type="long" />
-    <instance-data label="last_delay" type="long" />
+    <instance-data label="last_offset" type="long" />
 
   </plugin>
 </ladspa>

--- a/plugins/offset-swh.lv2/plugin.xml
+++ b/plugins/offset-swh.lv2/plugin.xml
@@ -19,7 +19,7 @@
 
   <plugin label="offset" id="1916" class="UtilityPlugin">
     <name>Offset, sample-based</name>
-    <p>Intended to be used to eliminate offset between tracks (e.g. single sound source recorded from different distances).</p>
+    <p>Intended to be used to eliminate offset between tracks (e.g. single sound source simultaneously recorded from different distances).</p>
 
     <callback event="instantiate"><![CDATA[
       buffer = calloc(BUFFER_LEN, sizeof(LADSPA_Data));
@@ -41,10 +41,10 @@
 
       if (automatable > 0) {
 
-        // report the maximum offset to the host
+        // report the maximum offset as latency to the host
         *(plugin_data->latency) = MAX_OFFSET;
 
-        // and subtract the maximum offset by default
+        // and delay by the maximum offset by default
         // (results in no audible offset)
         buffer_r_pos = BUFFER_POS(buffer_w_pos - MAX_OFFSET);
 
@@ -61,7 +61,7 @@
         buffer_r_pos = BUFFER_POS(buffer_w_pos + MIN((long)offset, 0));
       }
 
-      // if the offset increases, zero the buffer accordingly
+      // if the offset increased, zero the buffer accordingly
       offset_delta = (long)offset - last_offset;
       for (; offset_delta>0; offset_delta--) {
         buffer[BUFFER_POS(buffer_r_pos - offset_delta)] = 0.0f;
@@ -89,7 +89,7 @@
 
     <port label="automatable" dir="input" type="control" hint="default_0,toggled">
       <name>automatable (possibly adds playback delay)</name>
-      <p>Turn this off if the offset does not change when rolling as the required buffer possibly adds a playback delay otherwise.</p>
+      <p>Turn this off if the offset does not change when rolling. Otherwise, the required buffer possibly adds a playback delay.</p>
     </port>
 
     <port label="input" dir="input" type="audio">

--- a/plugins/offset-swh.lv2/plugin.xml
+++ b/plugins/offset-swh.lv2/plugin.xml
@@ -60,7 +60,7 @@
       plugin_data->last_delay = (long)delay;
     ]]></callback>
 
-    <port label="delay" dir="input" type="control" hint="default_0">
+    <port label="delay" dir="input" type="control" hint="default_0,causes_artifacts">
       <name>delay (in samples)</name>
       <range min="-24000" max="24000" steps="48001"/>
     </port>

--- a/plugins/offset-swh.lv2/plugin.xml
+++ b/plugins/offset-swh.lv2/plugin.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<!DOCTYPE ladspa SYSTEM "ladspa-swh.dtd">
+<?xml-stylesheet href="ladspa.css" type="text/css"?>
+
+<ladspa>
+  <global>
+    <meta name="maker" value="Lukas Pirl &lt;lv2@lukas-pirl.de&gt;"/>
+    <meta name="copyright" value="GPL"/>
+    <meta name="properties" value="HARD_RT_CAPABLE"/>
+    <code><![CDATA[
+      #include "ladspa-util.h"
+      #define MAX_OFFSET 24000
+      #define BUFFER_LEN (MAX_OFFSET*2 + 1)
+      #define BUFFER_POS(a) (((a) + BUFFER_LEN) % BUFFER_LEN)
+    ]]></code>
+  </global>
+
+  <plugin label="offset" id="1916" class="UtilityPlugin">
+    <name>Offset, sample-based (i.e. positive or negative delay)</name>
+    <p>Intended to be used to eliminate offset between tracks (e.g. single sound source recorded from different distances).</p>
+
+    <callback event="instantiate"><![CDATA[
+      buffer = calloc(BUFFER_LEN, sizeof(LADSPA_Data));
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(buffer, 0, BUFFER_LEN * sizeof(LADSPA_Data));
+      plugin_data->buffer_w_pos = 0;
+      plugin_data->last_delay = 0; //(float)*plugin_data->delay;
+      *(plugin_data->latency) = MAX_OFFSET;
+    ]]></callback>
+
+    <callback event="cleanup"><![CDATA[
+      free(plugin_data->buffer);
+    ]]></callback>
+
+    <callback event="run"><![CDATA[
+
+      long buffer_r_pos, i;
+
+      // subtract the plugin's latency (results in no audible offset)
+      // and apply user-configured delay (results in the desired offset):
+      buffer_r_pos = BUFFER_POS(buffer_w_pos - (MAX_OFFSET + (long)delay));
+
+      //for (i=0; i<delay_delta; i++) {
+      //  buffer[BUFFER_POS(buffer_w_pos + i)] = 0;
+      //}
+
+      for (i=0; i<sample_count; i++) {
+        buffer[buffer_w_pos] = input[i];
+        buffer_w_pos = BUFFER_POS(buffer_w_pos + 1);
+
+        buffer_write(output[i], buffer[buffer_r_pos]);
+        buffer[buffer_r_pos] = 0.0f;
+        buffer_r_pos = BUFFER_POS(buffer_r_pos + 1);
+      }
+
+      plugin_data->buffer_w_pos = buffer_w_pos;
+      plugin_data->last_delay = (long)delay;
+    ]]></callback>
+
+    <port label="delay" dir="input" type="control" hint="default_0">
+      <name>delay (in samples)</name>
+      <range min="-24000" max="24000" steps="48001"/>
+    </port>
+
+    <port label="input" dir="input" type="audio">
+      <name>Input</name>
+    </port>
+
+    <port label="output" dir="output" type="audio">
+      <name>Output</name>
+    </port>
+
+    <port label="latency" dir="output" type="control">
+      <name>latency</name>
+    </port>
+
+    <!-- this is a ring buffer -->
+    <instance-data label="buffer" type="LADSPA_Data *" />
+
+    <instance-data label="buffer_w_pos" type="long" />
+    <instance-data label="last_delay" type="long" />
+
+  </plugin>
+</ladspa>

--- a/xslt/turtle.xsl
+++ b/xslt/turtle.xsl
@@ -77,6 +77,8 @@ swh:<xsl:value-of select="$pluglabel"/> a :Plugin ;
      :portProperty :sampleRate ;</xsl:if>
      <xsl:if test="contains(@hint, 'toggled')">
      :portProperty :toggled ;</xsl:if>
+     <xsl:if test="contains(@hint, 'causes_artifacts')">
+     :portProperty :causesArtifacts ;</xsl:if>
      <xsl:if test="@group">
      pg:inGroup swh:<xsl:value-of select="$pluglabel"/>-<xsl:value-of select="@group"/> ;
      pg:role pg:<xsl:value-of select="@role"/> ;</xsl:if>

--- a/xslt/turtle.xsl
+++ b/xslt/turtle.xsl
@@ -46,7 +46,8 @@ swh:<xsl:value-of select="$pluglabel"/> a :Plugin ;
      :index <xsl:number value="position()-1" format="1" /> ;
      :symbol "<xsl:value-of select="@label"/>" ;<xsl:for-each select="range">
      :minimum <xsl:value-of select="@min"/> ;
-     :maximum <xsl:value-of select="@max"/> ;</xsl:for-each>
+     :maximum <xsl:value-of select="@max"/> ;
+     <xsl:if test="@steps">:rangeSteps <xsl:value-of select="@steps"/> ;</xsl:if></xsl:for-each>
      <xsl:if test="@label = 'latency'">
      :portProperty :reportsLatency ;</xsl:if>
      <xsl:if test="contains(@hint, 'default_0')">


### PR DESCRIPTION
As discussed in #10, I created a plugin to apply positive and negative delays to audio.

I named it simply "offset" since during development, I had the thought that there is actually no reason why it should have "artificial" in its name.

Another notable difference is that I added a toggle button to let the user decide if the offset should be automatable or not. The reason is the following:
If it should be automatable, the plug-in must always report its maximum latency to the host in order to be able to possibly apply the (positive) maximum offset when rolling. This inherently leads to a delay when starting the transport if the plug-in is not actually set to the maximum offset.
When this option is disabled, the plug-in will always report its currently minimum required latency, which avoids a delay when starting the transport.

Also, I added a two tiny extensions to the markup language.

You can either pull in the commits as they are or ask me to squash all or some of them in case you don't like some changes.