### PR TITLE
Allocate memory during instantiation, fixing segfaults in a few plugins

### DIFF
--- a/plugins/allpass-swh.lv2/plugin.xml
+++ b/plugins/allpass-swh.lv2/plugin.xml
@@ -42,28 +42,24 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
       unsigned int minsize, size;
     
-      if (plugin_data->max_delay && *plugin_data->max_delay > 0)
-        minsize = sample_rate * *plugin_data->max_delay;
-      else if (plugin_data->delay_time)
-        minsize = sample_rate * *plugin_data->delay_time;
-      else
-        minsize = sample_rate; /* 1 second default */
+      minsize = sample_rate * 10; /* 10 seconds buffer */
     
       size = 1;
       while (size < minsize) size <<= 1;
     
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(float));
-      if (plugin_data->buffer)
-        plugin_data->buffer_mask = size - 1;
+      buffer = calloc(size, sizeof(float));
+      if (buffer)
+        buffer_mask = size - 1;
       else
-        plugin_data->buffer_mask = 0;
-      plugin_data->write_phase = 0;
+        buffer_mask = 0;
+      write_phase = 0;
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(plugin_data->buffer, 0, (plugin_data->buffer_mask + 1) * sizeof(LADSPA_Data));
     ]]></callback>
     
     <callback event="cleanup"><![CDATA[
@@ -186,9 +182,7 @@
       <name>Max Delay (s)</name>
       <range min="0" max="10"/>
       <p>
-       Maximum delay. Used to set the delay buffer size upon activation. Cannot
-       be modulated. Note that if you do not connect to this port before
-       activation, it will default to 1 second. 
+       This has no effect and is left in for interface backwards compatibility.
       </p>
     </port>
 
@@ -225,28 +219,24 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
       unsigned int minsize, size;
     
-      if (plugin_data->max_delay && *plugin_data->max_delay > 0)
-        minsize = sample_rate * *plugin_data->max_delay;
-      else if (plugin_data->delay_time)
-        minsize = sample_rate * *plugin_data->delay_time;
-      else
-        minsize = sample_rate; /* 1 second default */
+      minsize = sample_rate * 10; /* 10 seconds buffer */
     
       size = 1;
       while (size < minsize) size <<= 1;
     
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(float));
-      if (plugin_data->buffer)
-        plugin_data->buffer_mask = size - 1;
+      buffer = calloc(size, sizeof(float));
+      if (buffer)
+        buffer_mask = size - 1;
       else
-        plugin_data->buffer_mask = 0;
-      plugin_data->write_phase = 0;
+        buffer_mask = 0;
+      write_phase = 0;
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(plugin_data->buffer, 0, (plugin_data->buffer_mask + 1) * sizeof(LADSPA_Data));
     ]]></callback>
     
     <callback event="cleanup"><![CDATA[
@@ -324,9 +314,7 @@
       <name>Max Delay (s)</name>
       <range min="0" max="10"/>
       <p>
-       Maximum delay. Used to set the delay buffer size upon activation. Cannot
-       be modulated. Note that if you do not connect to this port before
-       activation, it will default to 1 second. 
+       This has no effect and is left in for interface backwards compatibility.
       </p>
     </port>
 
@@ -363,28 +351,24 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
       unsigned int minsize, size;
     
-      if (plugin_data->max_delay && *plugin_data->max_delay > 0)
-        minsize = sample_rate * *plugin_data->max_delay;
-      else if (plugin_data->delay_time)
-        minsize = sample_rate * *plugin_data->delay_time;
-      else
-        minsize = sample_rate; /* 1 second default */
+      minsize = sample_rate * 10; /* 10 seconds buffer */
     
       size = 1;
       while (size < minsize) size <<= 1;
     
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(float));
-      if (plugin_data->buffer)
-        plugin_data->buffer_mask = size - 1;
+      buffer = calloc(size, sizeof(float));
+      if (buffer)
+        buffer_mask = size - 1;
       else
-        plugin_data->buffer_mask = 0;
-      plugin_data->write_phase = 0;
+        buffer_mask = 0;
+      write_phase = 0;
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(plugin_data->buffer, 0, (plugin_data->buffer_mask + 1) * sizeof(LADSPA_Data));
     ]]></callback>
     
     <callback event="cleanup"><![CDATA[
@@ -465,9 +449,7 @@
       <name>Max Delay (s)</name>
       <range min="0" max="10"/>
       <p>
-       Maximum delay. Used to set the delay buffer size upon activation. Cannot
-       be modulated. Note that if you do not connect to this port before
-       activation, it will default to 1 second. 
+       This has no effect and is left in for interface backwards compatibility.
       </p>
     </port>
 

--- a/plugins/bandpass_a_iir-swh.lv2/plugin.xml
+++ b/plugins/bandpass_a_iir-swh.lv2/plugin.xml
@@ -19,6 +19,8 @@
 
                 <callback event="instantiate">
                   sample_rate = s_rate;
+                  gt = init_iir_stage(IIR_STAGE_LOWPASS,1,3,2);
+                  iirf = init_iirf_t(gt);
                 </callback>
 		<callback event="run">
                   calc_2polebandpass(iirf, gt, center, width, sample_rate);
@@ -26,8 +28,6 @@
                 </callback>
 
                 <callback event="activate">                  
-                  plugin_data->gt = init_iir_stage(IIR_STAGE_LOWPASS,1,3,2);
-                  plugin_data->iirf = init_iirf_t(plugin_data->gt);
                   calc_2polebandpass(iirf, plugin_data->gt, *(plugin_data->center), *(plugin_data->width), sample_rate);
                 </callback>
 

--- a/plugins/bandpass_iir-swh.lv2/plugin.xml
+++ b/plugins/bandpass_iir-swh.lv2/plugin.xml
@@ -21,6 +21,10 @@
 
                 <callback event="instantiate">
                   sample_rate = s_rate;
+                  first = init_iir_stage(IIR_STAGE_LOWPASS,10,3,2);
+                  second = init_iir_stage(IIR_STAGE_HIGHPASS,10,3,2);                  
+                  gt = init_iir_stage(IIR_STAGE_BANDPASS,20,3,2); 
+                  iirf = init_iirf_t(gt);
                 </callback>
 		<callback event="run">
                   ufc = (center + width*0.5f)/(float)sample_rate;
@@ -34,10 +38,6 @@
                 <callback event="activate">                  
                   plugin_data->ufc = (*(plugin_data->center) + *(plugin_data->width)*0.5f)/(float)sample_rate;
                   plugin_data->lfc = (*(plugin_data->center) - *(plugin_data->width)*0.5f)/(float)sample_rate;
-                  plugin_data->first = init_iir_stage(IIR_STAGE_LOWPASS,10,3,2);
-                  plugin_data->second = init_iir_stage(IIR_STAGE_HIGHPASS,10,3,2);                  
-                  plugin_data->gt = init_iir_stage(IIR_STAGE_BANDPASS,20,3,2); 
-                  plugin_data->iirf = init_iirf_t(plugin_data->gt);
                   chebyshev(plugin_data->iirf, plugin_data->first, 2*CLAMP((int)(*(plugin_data->stages)),1,10), IIR_STAGE_LOWPASS, plugin_data->ufc, 0.5f);
                   chebyshev(plugin_data->iirf, plugin_data->second, 2*CLAMP((int)(*(plugin_data->stages)),1,10), IIR_STAGE_HIGHPASS, plugin_data->lfc, 0.5f);
                   combine_iir_stages(IIR_STAGE_BANDPASS, plugin_data->gt, plugin_data->first, plugin_data->second,0,0);

--- a/plugins/butterworth-swh.lv2/plugin.xml
+++ b/plugins/butterworth-swh.lv2/plugin.xml
@@ -19,6 +19,8 @@
 
                 <callback event="instantiate">
                   sample_rate = s_rate;
+                  gt = init_iir_stage(IIR_STAGE_LOWPASS,1,3,2);
+                  iirf = init_iirf_t(gt);
                 </callback>
 		<callback event="run">
                   butterworth_stage(gt, 0, cutoff, resonance, sample_rate);
@@ -27,8 +29,6 @@
                 </callback>
 
                 <callback event="activate">                  
-                  plugin_data->gt = init_iir_stage(IIR_STAGE_LOWPASS,1,3,2);
-                  plugin_data->iirf = init_iirf_t(plugin_data->gt);
                   butterworth_stage(plugin_data->gt, 0, *(plugin_data->cutoff), 
 		  			   *(plugin_data->resonance), 
 					   sample_rate);
@@ -74,6 +74,8 @@
 
                 <callback event="instantiate">
                   sample_rate = s_rate;
+                  gt = init_iir_stage(IIR_STAGE_LOWPASS,1,3,2);
+                  iirf = init_iirf_t(gt);
                 </callback>
 		<callback event="run">
                   butterworth_stage(gt, 0, cutoff, resonance, sample_rate);
@@ -81,8 +83,6 @@
                 </callback>
 
                 <callback event="activate">                  
-                  plugin_data->gt = init_iir_stage(IIR_STAGE_LOWPASS,1,3,2);
-                  plugin_data->iirf = init_iirf_t(plugin_data->gt);
                   butterworth_stage(plugin_data->gt, 0, *(plugin_data->cutoff), 
 		  			   *(plugin_data->resonance), 
 					   sample_rate);
@@ -124,6 +124,8 @@
 
                 <callback event="instantiate">
                   sample_rate = s_rate;
+                  gt = init_iir_stage(IIR_STAGE_LOWPASS,1,3,2);
+                  iirf = init_iirf_t(gt);
                 </callback>
 		<callback event="run">
                   butterworth_stage(gt, 1, cutoff, resonance, sample_rate);
@@ -131,8 +133,6 @@
                 </callback>
 
                 <callback event="activate">                  
-                  plugin_data->gt = init_iir_stage(IIR_STAGE_LOWPASS,1,3,2);
-                  plugin_data->iirf = init_iirf_t(plugin_data->gt);
                   butterworth_stage(plugin_data->gt, 1, *(plugin_data->cutoff), 
 		  			   *(plugin_data->resonance), 
 					   sample_rate);

--- a/plugins/comb-swh.lv2/plugin.xml
+++ b/plugins/comb-swh.lv2/plugin.xml
@@ -39,28 +39,24 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
       unsigned int minsize, size;
    
-      if (plugin_data->max_delay && *plugin_data->max_delay > 0)
-        minsize = sample_rate * *plugin_data->max_delay;
-      else if (plugin_data->delay_time)
-        minsize = sample_rate * *plugin_data->delay_time;
-      else
-        minsize = sample_rate; /* 1 second default */
+      minsize = sample_rate * 10; /* 10 seconds buffer */
     
       size = 1;
       while (size < minsize) size <<= 1;
     
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(LADSPA_Data));
-      if (plugin_data->buffer)
-        plugin_data->buffer_mask = size - 1;
+      buffer = calloc(size, sizeof(LADSPA_Data));
+      if (buffer)
+        buffer_mask = size - 1;
       else
-        plugin_data->buffer_mask = 0;
-      plugin_data->write_phase = 0;
+        buffer_mask = 0;
+      write_phase = 0;
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(plugin_data->buffer, 0, (plugin_data->buffer_mask + 1) * sizeof(LADSPA_Data));
     ]]></callback>
     
     <callback event="cleanup"><![CDATA[
@@ -180,9 +176,7 @@
       <name>Max Delay (s)</name>
       <range min="0" max="10"/>
       <p>
-       Maximum delay. Used to set the delay buffer size upon activation. Cannot
-       be modulated. Note that if you do not connect to this port before
-       activation, it will default to 1 second. 
+       This has no effect and is left in for interface backwards compatibility.
       </p>
     </port>
 
@@ -219,28 +213,24 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
       unsigned int minsize, size;
-    
-      if (plugin_data->max_delay && *plugin_data->max_delay > 0)
-        minsize = sample_rate * *plugin_data->max_delay;
-      else if (plugin_data->delay_time)
-        minsize = sample_rate * *plugin_data->delay_time;
-      else
-        minsize = sample_rate; /* 1 second default */
+   
+      minsize = sample_rate * 10; /* 10 seconds buffer */
     
       size = 1;
       while (size < minsize) size <<= 1;
     
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(LADSPA_Data));
-      if (plugin_data->buffer)
-        plugin_data->buffer_mask = size - 1;
+      buffer = calloc(size, sizeof(LADSPA_Data));
+      if (buffer)
+        buffer_mask = size - 1;
       else
-        plugin_data->buffer_mask = 0;
-      plugin_data->write_phase = 0;
+        buffer_mask = 0;
+      write_phase = 0;
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(plugin_data->buffer, 0, (plugin_data->buffer_mask + 1) * sizeof(LADSPA_Data));
     ]]></callback>
     
     <callback event="cleanup"><![CDATA[
@@ -318,9 +308,7 @@
       <name>Max Delay (s)</name>
       <range min="0" max="10"/>
       <p>
-       Maximum delay. Used to set the delay buffer size upon activation. Cannot
-       be modulated. Note that if you do not connect to this port before
-       activation, it will default to 1 second. 
+       This has no effect and is left in for interface backwards compatibility.
       </p>
     </port>
 
@@ -357,28 +345,24 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
       unsigned int minsize, size;
-    
-      if (plugin_data->max_delay && *plugin_data->max_delay > 0)
-        minsize = sample_rate * *plugin_data->max_delay;
-      else if (plugin_data->delay_time)
-        minsize = sample_rate * *plugin_data->delay_time;
-      else
-        minsize = sample_rate; /* 1 second default */
+   
+      minsize = sample_rate * 10; /* 10 seconds buffer */
     
       size = 1;
       while (size < minsize) size <<= 1;
     
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(LADSPA_Data));
-      if (plugin_data->buffer)
-        plugin_data->buffer_mask = size - 1;
+      buffer = calloc(size, sizeof(LADSPA_Data));
+      if (buffer)
+        buffer_mask = size - 1;
       else
-        plugin_data->buffer_mask = 0;
-      plugin_data->write_phase = 0;
+        buffer_mask = 0;
+      write_phase = 0;
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(plugin_data->buffer, 0, (plugin_data->buffer_mask + 1) * sizeof(LADSPA_Data));
     ]]></callback>
     
     <callback event="cleanup"><![CDATA[
@@ -460,9 +444,7 @@
       <name>Max Delay (s)</name>
       <range min="0" max="10"/>
       <p>
-       Maximum delay. Used to set the delay buffer size upon activation. Cannot
-       be modulated. Note that if you do not connect to this port before
-       activation, it will default to 1 second. 
+       This has no effect and is left in for interface backwards compatibility.
       </p>
     </port>
 

--- a/plugins/delay-swh.lv2/plugin.xml
+++ b/plugins/delay-swh.lv2/plugin.xml
@@ -25,28 +25,24 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
       unsigned int minsize, size;
     
-      if (plugin_data->max_delay && *plugin_data->max_delay > 0)
-        minsize = sample_rate * *plugin_data->max_delay;
-      else if (plugin_data->delay_time)
-        minsize = sample_rate * *plugin_data->delay_time;
-      else
-        minsize = sample_rate; /* 1 second default */
+      minsize = sample_rate * 10; /* 10 seconds buffer */
     
       size = 1;
       while (size < minsize) size <<= 1;
     
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(LADSPA_Data));
-      if (plugin_data->buffer)
-        plugin_data->buffer_mask = size - 1;
+      buffer = calloc(size, sizeof(LADSPA_Data));
+      if (buffer)
+        buffer_mask = size - 1;
       else
-        plugin_data->buffer_mask = 0;
-      plugin_data->write_phase = 0;
+        buffer_mask = 0;
+      write_phase = 0;
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(plugin_data->buffer, 0, (plugin_data->buffer_mask + 1) * sizeof(LADSPA_Data));
     ]]></callback>
     
     <callback event="cleanup"><![CDATA[
@@ -126,9 +122,7 @@
       <name>Max Delay (s)</name>
       <range min="0" max="10"/>
       <p>
-       Maximum delay. Used to set the delay buffer size upon activation. Cannot
-       be modulated. Note that if you do not connect to this port before
-       activation, it will default to 1 second. 
+       This has no effect and is left in for interface backwards compatibility.
       </p>
     </port>
 
@@ -153,28 +147,24 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
       unsigned int minsize, size;
     
-      if (plugin_data->max_delay && *plugin_data->max_delay > 0)
-        minsize = sample_rate * *plugin_data->max_delay;
-      else if (plugin_data->delay_time)
-        minsize = sample_rate * *plugin_data->delay_time;
-      else
-        minsize = sample_rate; /* 1 second default */
+      minsize = sample_rate * 10; /* 10 seconds buffer */
     
       size = 1;
       while (size < minsize) size <<= 1;
     
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(LADSPA_Data));
-      if (plugin_data->buffer)
-        plugin_data->buffer_mask = size - 1;
+      buffer = calloc(size, sizeof(LADSPA_Data));
+      if (buffer)
+        buffer_mask = size - 1;
       else
-        plugin_data->buffer_mask = 0;
-      plugin_data->write_phase = 0;
+        buffer_mask = 0;
+      write_phase = 0;
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(plugin_data->buffer, 0, (plugin_data->buffer_mask + 1) * sizeof(LADSPA_Data));
     ]]></callback>
     
     <callback event="cleanup"><![CDATA[
@@ -242,9 +232,7 @@
       <name>Max Delay (s)</name>
       <range min="0" max="10"/>
       <p>
-       Maximum delay. Used to set the delay buffer size upon activation. Cannot
-       be modulated. Note that if you do not connect to this port before
-       activation, it will default to 1 second. 
+       This has no effect and is left in for interface backwards compatibility.
       </p>
     </port>
 
@@ -269,28 +257,24 @@
     
     <callback event="instantiate"><![CDATA[
       sample_rate = s_rate;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
       unsigned int minsize, size;
     
-      if (plugin_data->max_delay && *plugin_data->max_delay > 0)
-        minsize = sample_rate * *plugin_data->max_delay;
-      else if (plugin_data->delay_time)
-        minsize = sample_rate * *plugin_data->delay_time;
-      else
-        minsize = sample_rate; /* 1 second default */
+      minsize = sample_rate * 10; /* 10 seconds buffer */
     
       size = 1;
       while (size < minsize) size <<= 1;
     
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(LADSPA_Data));
-      if (plugin_data->buffer)
-        plugin_data->buffer_mask = size - 1;
+      buffer = calloc(size, sizeof(LADSPA_Data));
+      if (buffer)
+        buffer_mask = size - 1;
       else
-        plugin_data->buffer_mask = 0;
-      plugin_data->write_phase = 0;
+        buffer_mask = 0;
+      write_phase = 0;
+    ]]></callback>
+
+    <callback event="activate"><![CDATA[
+      memset(plugin_data->buffer, 0, (plugin_data->buffer_mask + 1) * sizeof(LADSPA_Data));
     ]]></callback>
     
     <callback event="cleanup"><![CDATA[
@@ -360,9 +344,7 @@
       <name>Max Delay (s)</name>
       <range min="0" max="10"/>
       <p>
-       Maximum delay. Used to set the delay buffer size upon activation. Cannot
-       be modulated. Note that if you do not connect to this port before
-       activation, it will default to 1 second. 
+       This has no effect and is left in for interface backwards compatibility.
       </p>
     </port>
 

--- a/plugins/highpass_iir-swh.lv2/plugin.xml
+++ b/plugins/highpass_iir-swh.lv2/plugin.xml
@@ -21,6 +21,8 @@
 
                 <callback event="instantiate">
                   sample_rate = s_rate;
+                  gt = init_iir_stage(IIR_STAGE_HIGHPASS,10,3,2);
+                  iirf = init_iirf_t(gt);
                 </callback>
 		<callback event="run">
                   chebyshev(iirf, gt, 2*CLAMP((int)stages,1,10), IIR_STAGE_HIGHPASS, cutoff/(float)sample_rate, 0.5f);
@@ -28,8 +30,6 @@
                 </callback>
 
                 <callback event="activate">                  
-                  plugin_data->gt = init_iir_stage(IIR_STAGE_HIGHPASS,10,3,2);
-                  plugin_data->iirf = init_iirf_t(plugin_data->gt);
                   chebyshev(plugin_data->iirf, plugin_data->gt, 2*CLAMP((int)(*(plugin_data->stages)),1,10), IIR_STAGE_HIGHPASS, *(plugin_data->cutoff)/(float)sample_rate, 0.5f);
                 </callback>
 

--- a/plugins/lowpass_iir-swh.lv2/plugin.xml
+++ b/plugins/lowpass_iir-swh.lv2/plugin.xml
@@ -22,6 +22,8 @@
 
                 <callback event="instantiate">
                   sample_rate = s_rate;
+                  gt = init_iir_stage(IIR_STAGE_LOWPASS,10,3,2);
+                  iirf = init_iirf_t(gt);
                 </callback>
 		<callback event="run">
                   chebyshev(iirf, gt, 2*CLAMP((int)stages,1,10), IIR_STAGE_LOWPASS, cutoff/(float)sample_rate, 0.5f);
@@ -29,8 +31,6 @@
                 </callback>
 
                 <callback event="activate">                  
-                  plugin_data->gt = init_iir_stage(IIR_STAGE_LOWPASS,10,3,2);
-                  plugin_data->iirf = init_iirf_t(plugin_data->gt);
                   chebyshev(plugin_data->iirf, plugin_data->gt, 2*CLAMP(f_round(*(plugin_data->stages)),1,10), IIR_STAGE_LOWPASS, 
                             *(plugin_data->cutoff)/(float)sample_rate, 0.5f);
                 </callback>

--- a/plugins/revdelay-swh.lv2/plugin.xml
+++ b/plugins/revdelay-swh.lv2/plugin.xml
@@ -32,15 +32,21 @@
       delay_samples = 0;
       last_delay_time = 0;
       write_phase = 0;
-    ]]></callback>
-    
-    <callback event="activate"><![CDATA[
+
       unsigned int size;
 
       size = sample_rate * 5 * 2; /* 5 second maximum */
         
       /* calloc sets the buffer to zero. */
-      plugin_data->buffer = calloc(size, sizeof(LADSPA_Data));
+      buffer = calloc(size, sizeof(LADSPA_Data));
+    ]]></callback>
+    
+    <callback event="activate"><![CDATA[
+      unsigned int size;
+
+      size = sample_rate * 5 * 2;
+        
+      memset(plugin_data->buffer, 0, size * sizeof(LADSPA_Data));
 
       plugin_data->buffer_size = size;
       plugin_data->write_phase = 0;


### PR DESCRIPTION
This fixes #8 and fixes #13 + segfaults when testing with [lv2lint](https://github.com/OpenMusicKontrollers/lv2lint) by moving memory allocation in affected plugins from activation to instantiation.

allpass, comb and delay should also not set the buffer size based on the `max_delay` control, which is now left as a dummy port. I guess the idea was to let users set the max buffer size as a means of manual memory optimization, but can cause issues (again, malloc during activation) and LV2 hosts usually don't let users set parameters upon instantiation.

Also would be great to eventually have another stable release tagged, we're currently packaging this for Arch Linux with this patch applied :)

Thanks!